### PR TITLE
chore: CI/CD 워크플로우 및 Biome 설정 업데이트

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "develop"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "develop"]
 
 jobs:
   build-and-test:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit"
   },
-  "ignoreSync": ["biome.json"]
+  "ignoreSync": ["biome.json"],
+  "css.lint.unknownAtRules": "ignore"
 }

--- a/biome.json
+++ b/biome.json
@@ -43,5 +43,11 @@
       "semicolons": "always",
       "arrowParentheses": "always"
     }
+  },
+  "css": {
+    "parser": {
+      "cssModules": true,
+      "tailwindDirectives": true
+    }
   }
 }

--- a/scripts/smart-commit.mjs
+++ b/scripts/smart-commit.mjs
@@ -73,9 +73,11 @@ async function main() {
     console.log(`📝 생성된 메시지: "${commitMsg}"`);
 
     // 4. 커밋
-    // 쌍따옴표 이스케이프 처리
-    const safeCommitMsg = commitMsg.replace(/"/g, '\\"');
-    execSync(`git commit -m "${safeCommitMsg}"`, { stdio: 'inherit' });
+    // stdin으로 안전하게 메시지 전달 (shell injection 방지)
+    execSync('git commit -F -', {
+      input: commitMsg,
+      stdio: ['pipe', 'inherit', 'inherit'],
+    });
 
     console.log('✅ 커밋 완료! (푸시는 직접 해주세요: git push)');
   } catch (error) {


### PR DESCRIPTION
## 📝 요약
CI/CD 워크플로우, Biome 설정, VS Code 설정을 업데이트하고 스마트 커밋 스크립트를 개선했습니다.

## 🛠️ 변경 사항
- CI/CD 워크플로우에서 `main` 브랜치 외 `develop` 브랜치도 포함하도록 트리거 변경.
- VS Code 설정에 CSS에서 알 수 없는 at-rules 무시 옵션 추가.
- Biome 설정에 CSS 파서 관련 옵션 (`cssModules`, `tailwindDirectives`) 추가.
- `scripts/smart-commit.mjs`에서 커밋 메시지 전달 방식을 `execSync`의 `-F -` 옵션과 `input`을 사용하여 개선하여 쉘 인젝션 방지.

## 💡 영향 및 주의사항 (Optional)
- `develop` 브랜치에서도 CI/CD 파이프라인이 실행될 수 있습니다.
- Biome 설정 변경으로 인해 CSS 관��� 코드 포맷팅 및 린팅 동작에 변화가 있을 수 있습니다.

---
_Gemini로 자동 생성된 PR입니다._
