### PR TITLE
chore: CI 워크플로우 디버깅용 /tmp 파일 목록 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,7 +55,8 @@ jobs:
         with:
           name: me-image
           path: /tmp
-
+      - name: Debug - List files in /tmp
+        run: ls -R /tmp
       - name: Copy image to server
         uses: appleboy/scp-action@master
         with:


### PR DESCRIPTION
## 📝 요약
CI/CD 워크플로우에서 `/tmp` 경로의 파일 목록을 확인할 수 있는 디버깅 단계를 추가했습니다.

## 🛠️ 변경 사항
- CI/CD 워크플로우 파일(`ci-cd.yml`)에 `/tmp` 경로의 파일 목록을 출력하는 `ls -R /tmp` 명령어를 추가했습니다.

## 💡 영향 및 주의사항 (Optional)
- CI/CD 실행 시 `/tmp` 경로에 어떤 파일들이 생성되는지 파악하여 디버깅에 활용할 수 있습니다.

---
_Gemini로 자동 생성된 PR입니다._
