### PR TITLE
chore: CI/CD 워크플로우 아티팩트 경로 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,13 +37,13 @@ jobs:
           context: .
           push: false # Set to true if using GHCR
           tags: me:latest
-          outputs: type=docker,dest=/tmp/me.tar
+          outputs: type=docker,dest=me.tar
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: me-image
-          path: /tmp/me.tar
+          path: me.tar
 
   # Uncomment and configure this job for Home Server Deployment
   deploy:
@@ -54,16 +54,15 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: me-image
-          path: /tmp
-      - name: Debug - List files in /tmp
-        run: ls -R /tmp
+          path: .
+
       - name: Copy image to server
         uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
-          source: "/tmp/me.tar"
+          source: "me.tar"
           target: "/tmp/me.tar"
 
       - name: Deploy via SSH


### PR DESCRIPTION
## 📝 요약
CI/CD 워크플로우에서 Docker 빌드 아티팩트 경로를 수정했습니다.

## 🛠️ 변경 사항
- Docker 빌드 시 `/tmp/me.tar` 대신 `me.tar`로 아티팩트 경로를 지정했습니다.
- `actions/upload-artifact` 액션에서 업로드할 아티팩트 경로를 `/tmp/me.tar`에서 `me.tar`로 변경했습니다.
- `actions/download-artifact` 액션에서 다운로드 경로를 `/tmp`에서 현재 디렉토리(`.`)로 변경했습니다.
- `appleboy/scp-action`에서 복사할 소스 파일 경로를 `/tmp/me.tar`에서 `me.tar`로 변경했습니다.

## 💡 영향 및 주의사항 (Optional)
- Docker 이미지 아티팩트의 저장 및 다운로드 경로가 변경되어, 기존 워크플로우에서 해당 경로를 참조���는 부분이 있다면 업데이트가 필요할 수 있습니다.
- 로컬 환경에서 CI/CD 워크플로우를 테스트할 때 Docker 빌드 결과물의 위치가 변경될 수 있습니다.

---
_Gemini로 자동 생성된 PR입니다._
