### PR TITLE
chore: CI/CD 워크플로우 SSH 배포 경로 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,7 +63,7 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           source: "me.tar"
-          target: "/tmp/me.tar"
+          target: "/tmp"
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@master
@@ -72,6 +72,8 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           script: |
+            ls -la /tmp/me.tar || echo "File not found at /tmp/me.tar"
+
             docker load -i /tmp/me.tar
             docker stop me || true
             docker rm me || true


### PR DESCRIPTION
## 📝 요약
CI/CD 워크플로우에서 SSH를 이용한 배포 시, tar 파일의 대상 경로를 수정했습니다.

## 🛠️ 변경 사항
- `.github/workflows/ci-cd.yml` 파일에서 SSH 배포 단계의 `target` 경로를 `/tmp/me.tar`에서 `/tmp`로 변경했습니다.
- 배포 스크립트 시작 부분에 `/tmp/me.tar` 파일 존재 여부를 확인하는 `ls -la` 명령어를 추가하여 디버깅을 용이하게 했습니다.

## 💡 영향 및 주의사항 (Optional)
- tar 파일이 `/tmp` 디렉토리 자체에 저장되므로, 이전과 달리 파일 이름이 명시되지 않습니다. `docker load` 명령어는 tar 파일명을 자동으로 인식하므로 기능상 문제는 없습니다.

---
_Gemini로 자동 생성된 PR입니다._
