### PR TITLE
chore: CI/CD 배포 경로 및 스크립트 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -63,7 +63,7 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           source: "me.tar"
-          target: "/tmp"
+          target: "/home/${{ secrets.USERNAME }}/"
 
       - name: Deploy via SSH
         uses: appleboy/ssh-action@master
@@ -72,9 +72,9 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
           script: |
-            ls -la /tmp/me.tar || echo "File not found at /tmp/me.tar"
-
-            docker load -i /tmp/me.tar
+            ls -la me.tar
+            docker load -i me.tar
+            rm me.tar
             docker stop me || true
             docker rm me || true
             docker run -d --restart unless-stopped -p 3000:3000 --name me me:latest


### PR DESCRIPTION
## 📝 요약
CI/CD 워크플로우에서 Docker 이미지 배포 경로를 변경하고 관련 스크립트를 수정했습니다.

## 🛠️ 변경 사항
- `appleboy/scp-action`의 `target` 경로를 `/tmp`에서 `/home/${{ secrets.USERNAME }}/`로 변경하여 SSH 배포 대상 경로를 사용자 홈 디렉토리로 수정했습니다.
- SSH 스크립트에서 `docker load` 명령의 파일 경로를 `/tmp/me.tar`에서 `me.tar`로 변경하여 수정된 대상 경로에 맞게 수정했습니다.
- 배포 후 `.tar` 파일을 삭제하도록 `rm me.tar` 명령을 추가했습니다.

## 💡 영향 및 주의사항 (Optional)
- 배포 대상 경로가 변경되었으므로, 기존 배포와 관련된 설정이 있다면 확인이 필요할 수 있습니다.

---
_Gemini로 자동 생성된 PR입니다._
