### PR TITLE
feat: PWA 기능 및 View Transitions 적용

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -269,16 +269,3 @@ body {
 .will-change-filter {
   will-change: filter;
 }
-
-@keyframes shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
-}
-
-.animate-shimmer {
-  animation: shimmer 2s infinite;
-}

--- a/app/globals.css
+++ b/app/globals.css
@@ -269,3 +269,16 @@ body {
 .will-change-filter {
   will-change: filter;
 }
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.animate-shimmer {
+  animation: shimmer 2s infinite;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -36,6 +36,13 @@ export const metadata: Metadata = {
     description: SITE_DESCRIPTION,
     siteName: SITE_NAME,
   },
+
+  manifest: '/manifest.webmanifest',
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'black-translucent',
+    title: SITE_NAME,
+  },
   twitter: {
     card: 'summary_large_image',
     title: SITE_NAME,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from '@/src/components/theme-provider';
 
 import { BASE_URL, SITE_DESCRIPTION, SITE_NAME } from '@/src/lib/utils/constants';
 import 'pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css';
+import { ViewTransitions } from '@/src/components/common/ViewTransitionContext';
 import Layout from '@/src/components/layout/Layout';
 
 export const viewport: Viewport = {
@@ -79,8 +80,10 @@ export default function RootLayout({
           forcedTheme="dark"
           disableTransitionOnChange
         >
-          <Layout />
-          {children}
+          <ViewTransitions>
+            <Layout />
+            {children}
+          </ViewTransitions>
         </ThemeProvider>
       </body>
     </html>

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from 'next';
+import { SITE_DESCRIPTION, SITE_NAME } from '@/src/lib/utils/constants';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: SITE_NAME,
+    short_name: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#000000',
+    theme_color: '#000000',
+    icons: [
+      {
+        src: '/icon.png',
+        sizes: 'any',
+        type: 'image/png',
+      },
+    ],
+  };
+}

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { MDXRemote } from 'next-mdx-remote/rsc';
 import rehypePrettyCode from 'rehype-pretty-code';
 import Content from '@/src/components/posts/Content';
@@ -25,6 +25,11 @@ export async function generateStaticParams() {
 
 export default async function PostPage({ params }: PageProps) {
   const { slug } = await params;
+
+  if (slug !== slug.toLowerCase()) {
+    redirect(`/posts/${slug.toLowerCase()}`);
+  }
+
   const post = getPostBySlug(slug);
   if (!post) notFound();
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
       "biome check --write --no-errors-on-unmatched"
     ]
   },
+  "packageManager": "pnpm@10.24.0",
   "pnpm": {
     "onlyBuiltDependencies": [
       "sharp",

--- a/src/components/common/ViewTransitionContext.tsx
+++ b/src/components/common/ViewTransitionContext.tsx
@@ -12,7 +12,7 @@ export function ViewTransitions({ children }: { children: ReactNode }) {
   // Ref to store the resolve function of the promise that waits for page load
   const finishViewTransition = useRef<(() => void) | null>(null);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Only responds to pathname changes.
   useEffect(() => {
     // When pathname changes, if there is a pending transition, resolve it.
     if (finishViewTransition.current) {

--- a/src/components/common/ViewTransitionContext.tsx
+++ b/src/components/common/ViewTransitionContext.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { createContext, type ReactNode, use, useCallback, useEffect, useRef } from 'react';
+
+const ViewTransitionContext = createContext<((href: string) => void) | null>(null);
+
+export function ViewTransitions({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Ref to store the resolve function of the promise that waits for page load
+  const finishViewTransition = useRef<(() => void) | null>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  useEffect(() => {
+    // When pathname changes, if there is a pending transition, resolve it.
+    if (finishViewTransition.current) {
+      finishViewTransition.current();
+      finishViewTransition.current = null;
+    }
+  }, [pathname]);
+
+  const triggerTransition = useCallback(
+    (href: string) => {
+      // Fallback if browser doesn't support View Transitions
+      if (!document.startViewTransition) {
+        router.push(href);
+        return;
+      }
+
+      // Start variable transition
+      document.startViewTransition(() => {
+        router.push(href);
+
+        // Return a promise that resolves when the useEffect above fires (route change complete)
+        return new Promise<void>((resolve) => {
+          finishViewTransition.current = resolve;
+        });
+      });
+    },
+    [router]
+  );
+
+  return (
+    <ViewTransitionContext.Provider value={triggerTransition}>
+      {children}
+    </ViewTransitionContext.Provider>
+  );
+}
+
+export function useViewTransition() {
+  return use(ViewTransitionContext);
+}

--- a/src/components/common/ViewTransitionLink.tsx
+++ b/src/components/common/ViewTransitionLink.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link, { type LinkProps } from 'next/link';
+import { useRouter } from 'next/navigation';
+import { type ReactNode, useCallback } from 'react';
+import { useViewTransition } from './ViewTransitionContext';
+
+interface Props extends LinkProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export default function ViewTransitionLink({ children, href, ...props }: Props) {
+  const router = useRouter();
+  const triggerTransition = useViewTransition();
+
+  const handleLinkClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault();
+
+      if (triggerTransition) {
+        triggerTransition(href.toString());
+      } else {
+        router.push(href.toString());
+      }
+    },
+    [href, router, triggerTransition]
+  );
+
+  return (
+    <Link href={href} {...props} onClick={handleLinkClick}>
+      {children}
+    </Link>
+  );
+}

--- a/src/components/home/carousel/CarouselAmbient.tsx
+++ b/src/components/home/carousel/CarouselAmbient.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { type MotionValue, motion, useTransform } from 'framer-motion';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 import type { Post } from '@/src/lib/obsidian/types';
 import { DEFAULT_COLOR, TAG_COLORS } from '@/src/lib/utils/constants';
 import { CAROUSEL_OVERLAP } from './constants';
@@ -11,42 +11,16 @@ interface Props {
   containerScrollX: MotionValue<number>;
   dataIndex?: number;
   priority?: boolean;
+  range?: number[];
 }
 
-export default function CarouselAmbient({ post, index, containerScrollX }: Props) {
+export default function CarouselAmbient({
+  post,
+  index,
+  containerScrollX,
+  range = [0, 0, 0],
+}: Props) {
   const itemRef = useRef<HTMLLIElement>(null);
-
-  const [range, setRange] = useState([
-    index * 320 - (320 - CAROUSEL_OVERLAP),
-    index * 320,
-    index * 320 + (320 - CAROUSEL_OVERLAP),
-  ]);
-
-  useEffect(() => {
-    const el = itemRef.current;
-    if (!el) return;
-
-    const handleResize = () => {
-      const width = el.offsetWidth;
-      const centerScroll = el.offsetLeft + width / 2 - window.innerWidth / 2;
-
-      const totalW = width - CAROUSEL_OVERLAP;
-      const extend = window.innerWidth / 3;
-      setRange([centerScroll - totalW - extend, centerScroll, centerScroll + totalW + extend]);
-    };
-
-    handleResize();
-
-    const resizeObserver = new ResizeObserver(() => handleResize());
-    resizeObserver.observe(el);
-
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
   const scale = useTransform(containerScrollX, range, [0.8, 1, 0.8]);
   const y = useTransform(containerScrollX, range, [40, 0, 40]);
   const z = useTransform(containerScrollX, range, [-100, 0, -100]);

--- a/src/components/home/carousel/CarouselItem.tsx
+++ b/src/components/home/carousel/CarouselItem.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import type { Post } from '@/src/lib/obsidian/types';
-import { cn } from '@/src/lib/utils/cn';
 import { DEFAULT_COLOR, TAG_COLORS } from '@/src/lib/utils/constants';
 import { CAROUSEL_OVERLAP } from './constants';
 
@@ -18,7 +17,6 @@ interface Props {
 
 export default function CarouselItem({ post, index, containerScrollX, priority = false }: Props) {
   const itemRef = useRef<HTMLLIElement>(null);
-  const [isLoading, setIsLoading] = useState(true);
 
   const [range, setRange] = useState([
     index * 320 - (320 - CAROUSEL_OVERLAP),
@@ -100,18 +98,13 @@ export default function CarouselItem({ post, index, containerScrollX, priority =
             style={{ '--tag-color': displayColor } as React.CSSProperties}
           />
 
-          <div className="relative aspect-3/4 w-full overflow-hidden rounded-xl border-reflection">
+          <div className="relative aspect-3/4 w-full overflow-hidden rounded-xl border-reflection bg-neutral-900">
             <Image
               src={post.thumbnail || '/thumbnail-fallback.jpg'}
               fill
               alt={`${post.title} 썸네일`}
-              className={cn(
-                'object-cover duration-700 ease-in-out',
-                isLoading ? 'scale-110 blur-xl grayscale' : 'scale-100 blur-0 grayscale-0'
-              )}
+              className="object-cover duration-700 ease-in-out"
               priority={priority}
-              onLoad={() => setIsLoading(false)}
-              sizes="(max-width: 768px) 80vw, 360px"
             />
           </div>
         </Link>

--- a/src/components/home/carousel/CarouselItem.tsx
+++ b/src/components/home/carousel/CarouselItem.tsx
@@ -1,8 +1,7 @@
-'use client';
 import { type MotionValue, motion, useTransform } from 'framer-motion';
 import Image from 'next/image';
-import Link from 'next/link';
 import { useRef } from 'react';
+import ViewTransitionLink from '@/src/components/common/ViewTransitionLink';
 import type { Post } from '@/src/lib/obsidian/types';
 import { DEFAULT_COLOR, TAG_COLORS } from '@/src/lib/utils/constants';
 import { CAROUSEL_OVERLAP } from './constants';
@@ -60,7 +59,7 @@ export default function CarouselItem({
         }}
         className="h-full w-full"
       >
-        <Link
+        <ViewTransitionLink
           href={`/posts/${post.slug}`}
           className="relative flex h-full w-[80vw] min-w-[300px] max-w-[360px] flex-col items-center justify-end rounded-2xl px-4 py-4"
         >
@@ -71,7 +70,10 @@ export default function CarouselItem({
             }}
           />
 
-          <div className="relative aspect-3/4 w-full overflow-hidden rounded-xl border-reflection bg-neutral-900">
+          <div
+            className="relative aspect-3/4 w-full overflow-hidden rounded-xl border-reflection bg-neutral-900"
+            style={{ viewTransitionName: `post-thumbnail-${post.slug}` } as React.CSSProperties}
+          >
             <Image
               src={post.thumbnail || '/thumbnail-fallback.jpg'}
               fill
@@ -80,7 +82,7 @@ export default function CarouselItem({
               priority={priority}
             />
           </div>
-        </Link>
+        </ViewTransitionLink>
       </motion.div>
     </motion.li>
   );

--- a/src/components/home/carousel/CarouselItem.tsx
+++ b/src/components/home/carousel/CarouselItem.tsx
@@ -1,8 +1,8 @@
 'use client';
-import { type MotionValue, motion, useMotionTemplate, useTransform } from 'framer-motion';
+import { type MotionValue, motion, useTransform } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 import type { Post } from '@/src/lib/obsidian/types';
 import { DEFAULT_COLOR, TAG_COLORS } from '@/src/lib/utils/constants';
 import { CAROUSEL_OVERLAP } from './constants';
@@ -13,52 +13,24 @@ interface Props {
   containerScrollX: MotionValue<number>;
   dataIndex?: number;
   priority?: boolean;
+  range?: number[];
 }
 
-export default function CarouselItem({ post, index, containerScrollX, priority = false }: Props) {
+export default function CarouselItem({
+  post,
+  index,
+  containerScrollX,
+  priority = false,
+  range = [0, 0, 0],
+}: Props) {
   const itemRef = useRef<HTMLLIElement>(null);
-
-  const [range, setRange] = useState([
-    index * 320 - (320 - CAROUSEL_OVERLAP),
-    index * 320,
-    index * 320 + (320 - CAROUSEL_OVERLAP),
-  ]);
-
-  useEffect(() => {
-    const el = itemRef.current;
-    if (!el) return;
-
-    const handleResize = () => {
-      const width = el.offsetWidth;
-      const centerScroll = el.offsetLeft + width / 2 - window.innerWidth / 2;
-
-      const totalW = width - CAROUSEL_OVERLAP;
-      const extend = window.innerWidth / 3;
-      setRange([centerScroll - totalW - extend, centerScroll, centerScroll + totalW + extend]);
-    };
-
-    // 초기 실행
-    handleResize();
-
-    // ResizeObserver: 요소의 크기 변화 감지 (이미지 로딩, 폰트 변경 등)
-    const resizeObserver = new ResizeObserver(() => handleResize());
-    resizeObserver.observe(el);
-
-    // Window Resize: 화면 크기 변화 감지
-    window.addEventListener('resize', handleResize);
-
-    return () => {
-      resizeObserver.disconnect();
-      window.removeEventListener('resize', handleResize);
-    };
-  }, []);
   const rotateY = useTransform(containerScrollX, range, [20, 0, -20]);
   const scale = useTransform(containerScrollX, range, [0.8, 1, 0.8]);
   const y = useTransform(containerScrollX, range, [40, 0, 40]);
   const z = useTransform(containerScrollX, range, [-100, 0, -100]);
   const zIndex = useTransform(containerScrollX, range, [0, 10, 0]);
-  const blurValue = useTransform(containerScrollX, range, [6, 0, 6]);
-  const filter = useMotionTemplate`blur(${blurValue}px)`;
+  // const blurValue = useTransform(containerScrollX, range, [6, 0, 6]);
+  // const filter = useMotionTemplate`blur(${blurValue}px)`;
 
   const mainTag = post.tags?.[0];
   const displayColor = (mainTag && TAG_COLORS[mainTag]) || DEFAULT_COLOR;
@@ -72,7 +44,7 @@ export default function CarouselItem({ post, index, containerScrollX, priority =
         y,
         z,
         zIndex,
-        filter,
+        // filter,
         marginRight: -CAROUSEL_OVERLAP,
       }}
       className="preserve-3d backface-hidden transform-sty snap-center snap-always will-change-transform last:mr-0"
@@ -92,10 +64,11 @@ export default function CarouselItem({ post, index, containerScrollX, priority =
           href={`/posts/${post.slug}`}
           className="relative flex h-full w-[80vw] min-w-[300px] max-w-[360px] flex-col items-center justify-end rounded-2xl px-4 py-4"
         >
-          {/* glow */}
           <div
-            className="absolute bottom-0 aspect-3/4 w-full transform-gpu rounded-xl bg-(--tag-color) opacity-5 blur-[32px] will-change-filter"
-            style={{ '--tag-color': displayColor } as React.CSSProperties}
+            className="absolute bottom-0 aspect-3/4 w-full transform-gpu opacity-60"
+            style={{
+              background: `linear-gradient(to top, ${displayColor}, transparent 50%)`,
+            }}
           />
 
           <div className="relative aspect-3/4 w-full overflow-hidden rounded-xl border-reflection bg-neutral-900">

--- a/src/components/home/carousel/TitleSync.tsx
+++ b/src/components/home/carousel/TitleSync.tsx
@@ -68,11 +68,14 @@ export default function TitleSync({
         >
           <h4
             className="break-keep text-center font-bold font-suite text-2xl text-transparent leading-[125%] md:text-4xl"
-            style={{
-              WebkitBackgroundClip: 'text',
-              background: `linear-gradient(to bottom, #ffffff, ${displayColor})`,
-              backgroundClip: 'text',
-            }}
+            style={
+              {
+                WebkitBackgroundClip: 'text',
+                background: `linear-gradient(to bottom, #ffffff, ${displayColor})`,
+                backgroundClip: 'text',
+                viewTransitionName: `post-title-${activePost.slug}`,
+              } as React.CSSProperties
+            }
           >
             {activePost.title}
           </h4>

--- a/src/components/posts/Content.tsx
+++ b/src/components/posts/Content.tsx
@@ -39,7 +39,7 @@ export default function Content({ post, children }: { post: Post; children: Reac
       </div>
       <article className="m-auto flex max-w-[700px] flex-col gap-4 bg-bg-default pb-40">
         <div className="relative aspect-square w-full bg-linear-to-t from-black to-transparent">
-          <div className="absolute top-0 z-1 h-full w-full bg-linear-to-t from-bg-default to-transparent" />
+          <div className="fade-in absolute top-0 z-1 animate-in bg-linear-to-t from-bg-default to-transparent duration-1000" />
           <div
             className="absolute h-full w-full"
             style={{ viewTransitionName: `post-thumbnail-${post.slug}` } as React.CSSProperties}

--- a/src/components/posts/Content.tsx
+++ b/src/components/posts/Content.tsx
@@ -40,16 +40,22 @@ export default function Content({ post, children }: { post: Post; children: Reac
       <article className="m-auto flex max-w-[700px] flex-col gap-4 bg-bg-default pb-40">
         <div className="relative aspect-square w-full bg-linear-to-t from-black to-transparent">
           <div className="absolute top-0 z-1 h-full w-full bg-linear-to-t from-bg-default to-transparent" />
-          <Image
-            src={post.thumbnail || '/thumbnail-fallback.jpg'}
-            fill
-            alt={`${post.title} 썸네일`}
-            style={{ objectFit: 'cover' }}
-          />
+          <div
+            className="absolute h-full w-full"
+            style={{ viewTransitionName: `post-thumbnail-${post.slug}` } as React.CSSProperties}
+          >
+            <Image
+              src={post.thumbnail || '/thumbnail-fallback.jpg'}
+              fill
+              alt={`${post.title} 썸네일`}
+              style={{ objectFit: 'cover' }}
+            />
+          </div>
         </div>
         <h1
           ref={sentinelRef}
           className="-mt-12 z-1 break-keep px-6 text-center font-semibold text-3xl text-text-highlight leading-[125%]"
+          style={{ viewTransitionName: `post-title-${post.slug}` } as React.CSSProperties}
         >
           {post.title}
         </h1>

--- a/src/components/ui/GNBMenu.tsx
+++ b/src/components/ui/GNBMenu.tsx
@@ -85,7 +85,7 @@ function EmailMenu({
       await navigator.clipboard.writeText('me@kimseungmin.dev');
       setCopied(true);
     } catch (e) {
-      window.open('mailto:me@kimseungmin.dev', '_blank', 'noopener noreferrer');
+      window.open('mailto:me@kimseungmin.dev', '_blank');
       console.error('클립보드 복사 실패:', e);
     }
   }

--- a/src/components/ui/GNBMenu.tsx
+++ b/src/components/ui/GNBMenu.tsx
@@ -32,9 +32,9 @@ function GithubMenu({
       target="_blank"
       rel="noopener noreferrer"
     >
-      <Github className="w-9 h-9 text-white" />
+      <Github className="h-9 w-9 text-white" />
       <span>{children}</span>
-      <ExternalLink className="opacity-50 text-white" />
+      <ExternalLink className="text-white opacity-50" />
     </a>
   );
 }
@@ -55,9 +55,9 @@ function InstagramMenu({
       target="_blank"
       rel="noopener noreferrer"
     >
-      <Instagram className="w-9 h-9 text-white" />
+      <Instagram className="h-9 w-9 text-white" />
       <span>{children}</span>
-      <ExternalLink className="opacity-50 text-white" />
+      <ExternalLink className="text-white opacity-50" />
     </a>
   );
 }
@@ -85,6 +85,7 @@ function EmailMenu({
       await navigator.clipboard.writeText('me@kimseungmin.dev');
       setCopied(true);
     } catch (e) {
+      window.open('mailto:me@kimseungmin.dev', '_blank', 'noopener noreferrer');
       console.error('클립보드 복사 실패:', e);
     }
   }
@@ -98,9 +99,9 @@ function EmailMenu({
       style={style}
     >
       <motion.div layout>
-        <Mail className="w-9 h-9 text-white" />
+        <Mail className="h-9 w-9 text-white" />
       </motion.div>
-      <motion.div layout className="relative overflow-x-hidden flex items-center justify-center">
+      <motion.div layout className="relative flex items-center justify-center overflow-x-hidden">
         <AnimatePresence mode="popLayout">
           {copied ? (
             <motion.span
@@ -110,7 +111,7 @@ function EmailMenu({
               animate={{ y: 0, opacity: 1 }}
               exit={{ y: -15, opacity: 0 }}
               transition={{ ease: [0.23, 1, 0.32, 1], duration: 0.4 }}
-              className="inline-block whitespace-nowrap font-semibold text-transparent bg-clip-text bg-linear-to-b from-white to-[#ffffff70]"
+              className="inline-block whitespace-nowrap bg-linear-to-b from-white to-[#ffffff70] bg-clip-text font-semibold text-transparent"
             >
               클립보드에 복사되었어요
             </motion.span>
@@ -122,7 +123,7 @@ function EmailMenu({
               animate={{ y: 0, opacity: 1 }}
               exit={{ y: -15, opacity: 0 }}
               transition={{ ease: [0.23, 1, 0.32, 1], duration: 0.4 }}
-              className="inline-block whitespace-nowrap text-transparent bg-clip-text bg-linear-to-b from-white to-[#ffffff70]"
+              className="inline-block whitespace-nowrap bg-linear-to-b from-white to-[#ffffff70] bg-clip-text text-transparent"
             >
               {children}
             </motion.span>
@@ -140,10 +141,10 @@ function MenuItem({ item, index }: MenuItemProps) {
       initial={{ y: 50, opacity: 0 }}
       animate={{ y: 0, opacity: 100 }}
       transition={{ ease: [0, 0.8, 0.2, 1], duration: 1, delay: index * 0.1 }}
-      className="px-8 py-3 flex justify-center items-center"
+      className="flex items-center justify-center px-8 py-3"
     >
       <MenuComp
-        className="text-transparent bg-clip-text bg-linear-to-b from-white to-[#ffffff70] cursor-pointer text-2xl font-suite uppercase font-bold flex gap-4 justify-center items-center transform-gpu"
+        className="flex transform-gpu cursor-pointer items-center justify-center gap-4 bg-linear-to-b from-white to-[#ffffff70] bg-clip-text font-bold font-suite text-2xl text-transparent uppercase"
         style={{ WebkitBackgroundClip: 'text' }}
       >
         {item}
@@ -158,30 +159,30 @@ interface MenuContainerProps {
 
 export default function GNBMenu({ menuHandler }: MenuContainerProps) {
   return (
-    <div className="fixed flex justify-center items-center inset-0 z-800 w-screen h-screen">
+    <div className="fixed inset-0 z-800 flex h-screen w-screen items-center justify-center">
       <motion.button
         type="button"
         onClick={(e) => {
           if (e.target === e.currentTarget) menuHandler();
         }}
-        className="absolute bg-[#000000a0] w-full h-full -z-10 transform-gpu"
+        className="-z-10 absolute h-full w-full transform-gpu bg-[#000000a0]"
         initial={{ backdropFilter: 'blur(0px)', opacity: 0 }}
         animate={{ backdropFilter: 'blur(24px)', opacity: 1 }}
         transition={{ ease: [0, 0.8, 0.2, 1], duration: 0.5 }}
       />
-      <div className="max-w-[1080px] w-full fixed top-0 mx-auto flex justify-end">
+      <div className="fixed top-0 mx-auto flex w-full max-w-[1080px] justify-end">
         <motion.button
           type="button"
           onClick={menuHandler}
-          className="cursor-pointer px-4 py-3 border-none bg-transparent text-white"
+          className="cursor-pointer border-none bg-transparent px-4 py-3 text-white"
           initial={{ rotate: -45 }}
           animate={{ rotate: 0 }}
           transition={{ ease: [0, 1, 0, 1], duration: 0.4 }}
         >
-          <X className="w-6 h-6" />
+          <X className="h-6 w-6" />
         </motion.button>
       </div>
-      <ul className="flex flex-col gap-12 list-none p-0 m-0">
+      <ul className="m-0 flex list-none flex-col gap-12 p-0">
         {MenuItems.map((item, index) => (
           <MenuItem key={item} item={item} index={index} />
         ))}

--- a/src/lib/obsidian/post.ts
+++ b/src/lib/obsidian/post.ts
@@ -16,7 +16,8 @@ export function getAllPosts(): Post[] {
   const allPostsData = fileNames
     .filter((fileName) => fileName.endsWith('.md'))
     .map((fileName) => {
-      const slug = fileName.replace(/\.md$/, '');
+      const slug = fileName.replace(/\.md$/, '').toLowerCase();
+
       const fullPath = path.join(postsDirectory, fileName);
       const fileContents = fs.readFileSync(fullPath, 'utf8');
       const { data, content } = matter(fileContents);
@@ -47,7 +48,18 @@ export function getAllPosts(): Post[] {
 
 export function getPostBySlug(slug: string): Post | null {
   try {
-    const fullPath = path.join(postsDirectory, `${slug}.md`);
+    const targetSlug = slug.toLowerCase();
+
+    const fileNames = fs.readdirSync(postsDirectory);
+    const matchedFileName = fileNames.find(
+      (fileName) => fileName.replace(/\.md$/, '').toLowerCase() === targetSlug
+    );
+
+    if (!matchedFileName) {
+      return null;
+    }
+
+    const fullPath = path.join(postsDirectory, matchedFileName);
     const fileContents = fs.readFileSync(fullPath, 'utf8');
     const { data, content } = matter(fileContents);
     const match = content.match(/!\[\[(.*?)(?:\|.*?)?\]\]/) || '';
@@ -82,8 +94,8 @@ export function getPostBySlug(slug: string): Post | null {
 
     return {
       thumbnail,
-      slug,
-      title: data.title || slug,
+      slug: targetSlug,
+      title: data.title || targetSlug,
       date: data.date || '',
       tags: data.tags || [],
       content: processedContent,


### PR DESCRIPTION
## 📝 요약
PWA 매니페스트 추가, View Transitions API를 활용한 부드러운 페이지 전환 기능 구현

## 🛠️ 변경 사항
- **PWA 기능 추가:** PWA 매니페스트 파일(`app/manifest.ts`) 및 관련 설정을 추가하여 웹 애플리케이션이 PWA로 작동하도록 구성했습니다.
- **View Transitions API 적용:**
    - `app/layout.tsx`에 `ViewTransitions` 컴포넌트를 감싸 페이지 전환 시 네이티브 브라우저 View Transitions API를 활용하도록 설정했습니다.
    - `src/components/common/ViewTransitionContext.tsx` 및 `src/components/common/ViewTransitionLink.tsx`를 추가하여 View Transitions 기능을 관리하고 `ViewTransitionLink` 컴포넌트를 통해 링크 클릭 시 전환을 트리거하도록 구���했습니다.
    - 캐러셀 컴포넌트(`CarouselContainer.tsx`, `CarouselItem.tsx`, `CarouselAmbient.tsx`)에서 `ViewTransitionLink`를 사용하여 해당 컴포넌트 내 링크 클릭 시에도 View Transitions가 작동하도록 수정했습니다.
- **슬러그(slug) 처리 개선:**
    - `/posts/[slug]/page.tsx`에서 슬러그를 소문자로 리디렉션하는 로직을 추가하여 슬러그 대소문자 불일치 문제를 해결했습니다.
    - `app/globals.css`에 `shimmer` 애니메이션 및 `animate-shimmer` 클래스를 추가했습니다. (구체적인 사용처는 코드에서 확인 필요)
- **Tailwind CSS 클래스 순서 최적화:** `src/components/ui/GNBMenu.tsx`에서 Tailwind CSS 클래스 순서를 최적화했습니다.

## 💡 영향 및 주의사항 (Optional)
- View Transitions API는 일부 브라우저에서만 지원됩니다. 지원되지 않는 브라우저의 경우 기존 `router.push` 방식으로 작동합니다.
- 캐러셀 컴포넌트의 `range` 계산 로직이 `CarouselContainer.tsx`에서 관리되도록 변경되었습니다.

---
_Gemini로 자동 생성된 PR입니다._
